### PR TITLE
Fix old syntax.

### DIFF
--- a/libraries/core/order.html
+++ b/libraries/core/order.html
@@ -63,13 +63,13 @@
 (compare-c {1 2 3} {2 3});=><Less></textarea></dd>
 
 <dt id="demo-min"><code>min</code></dt>
-<dd><textarea class="code">(min {10 20 5 20 30});=>5</textarea></dd>
+<dd><textarea class="code">(min 10 20 5 20 30);=>5</textarea></dd>
 
 <dt id="demo-min-fn"><code>min/fn</code></dt>
 <dd><textarea class="code">(min/fn compare {10 20 5 20 30});=>5</textarea></dd>
 
 <dt id="demo-max"><code>max</code></dt>
-<dd><textarea class="code">(max {10 20 5 20 30});=>30</textarea></dd>
+<dd><textarea class="code">(max 10 20 5 20 30);=>30</textarea></dd>
 
 <dt id="demo-max-fn"><code>max/fn</code></dt>
 <dd><textarea class="code">(max/fn compare {10 20 5 20 30});=>30</textarea></dd>

--- a/manual/patterns.html
+++ b/manual/patterns.html
@@ -199,18 +199,18 @@ In this pattern, the <i>variable</i> is regarded as an <a href="./basics.html#ha
 
 <h3 id="not-patterns">Not-Patterns</h3>
 
-<pre><code>^<i>pattern</i></code></pre>
+<pre><code>!<i>pattern</i></code></pre>
 
 <p>
-  A not-pattern matches with a object if the object does not matches the pattern following after <code>^</code>.
+  A not-pattern matches with a object if the object does not matches the pattern following after <code>!</code>.
 </p>
 
 <textarea class="code">(match 1 integer {[,2 #t] [_ #f]});=>#f
-(match 1 integer {[^,2 #t] [_ #f]});=>#t
+(match 1 integer {[!,2 #t] [_ #f]});=>#t
 (match {2 3 4} (multiset integer) {[<cons ,1 _> #t] [_ #f]});=>#f
-(match {2 3 4} (multiset integer) {[^<cons ,1 _> #t] [_ #f]});=>#t
-(match {1 1 2} (multiset integer) {[^<cons ,1 _> #t] [_ #f]});=>#f
-(match {1 1 2} (multiset integer) {[<cons ^,1 _> #t] [_ #f]});=>#t</textarea>
+(match {2 3 4} (multiset integer) {[!<cons ,1 _> #t] [_ #f]});=>#t
+(match {1 1 2} (multiset integer) {[!<cons ,1 _> #t] [_ #f]});=>#f
+(match {1 1 2} (multiset integer) {[<cons !,1 _> #t] [_ #f]});=>#t</textarea>
 
 <h3 id="and-patterns">And-Patterns</h3>
 

--- a/templates/tables/syntax.html
+++ b/templates/tables/syntax.html
@@ -38,7 +38,7 @@
     <tr>
       <td>Patterns</td>
       <td>
-        <a href="/manual/patterns.html#wildcard"><code>_</code></a> <a href="/manual/patterns.html#pattern-variable"><code>$<i>var</i></code></a> <a href="/manual/patterns.html#value-patterns"><code>,<i>val</i></code></a> <a href="/manual/patterns.html#predicate-patterns"><code>?<i>predicate</i></code></a> <a href="/manual/patterns.html#"><code>[ ]</code></a> <a href="/manual/patterns.html#inductive-patterns"><code>&lt;<i>p</i> &gt;</code></a> <a href="/manual/patterns.html#and-patterns"><code>(& )</code></a> <a href="/manual/patterns.html#or-patterns"><code>(| )</code></a> <a href="/manual/patterns.html#not-patterns"><code>^</code></a> <a href="/manual/patterns.html#loop-patterns"><code>(loop ...)</code></a> <a href="/manual/patterns.html#pattern-function"><code>pattern-function</code></a>
+        <a href="/manual/patterns.html#wildcard"><code>_</code></a> <a href="/manual/patterns.html#pattern-variable"><code>$<i>var</i></code></a> <a href="/manual/patterns.html#value-patterns"><code>,<i>val</i></code></a> <a href="/manual/patterns.html#predicate-patterns"><code>?<i>predicate</i></code></a> <a href="/manual/patterns.html#"><code>[ ]</code></a> <a href="/manual/patterns.html#inductive-patterns"><code>&lt;<i>p</i> &gt;</code></a> <a href="/manual/patterns.html#and-patterns"><code>(& )</code></a> <a href="/manual/patterns.html#or-patterns"><code>(| )</code></a> <a href="/manual/patterns.html#not-patterns"><code>!</code></a> <a href="/manual/patterns.html#loop-patterns"><code>(loop ...)</code></a> <a href="/manual/patterns.html#pattern-function"><code>pattern-function</code></a>
     </tr>
     <tr>
       <td>Matchers</td>


### PR DESCRIPTION
I've found that there are still old Egison's syntax on the manual.

* Update usage of `max` and `min`.
  * It seems that they can no longer get `Collection` because `cambda` function is used internally.
* Update "Not-pattern" from `^` to `!`.