### PR TITLE
Fix style of dropdown menu

### DIFF
--- a/egison.css
+++ b/egison.css
@@ -155,6 +155,12 @@ pre.prettyprint {
 
 }
 
+.navbar-nav .dropdown .dropdown-menu {
+  height: auto;
+  max-height: calc(100vh - 50px); /* viewport height - .navbar height */
+  overflow-x: hidden;
+}
+
 /* CUSTOMIZE THE SIDENAV
    -------------------------------------------------- */
 


### PR DESCRIPTION
Because the bootstrap dropdown menu is fixed, the items at the bottom of the menu aren't displayed in some cases. In my case, the viewport height is 752px and the items at the bottom of the menu aren't displayed.