### PR TITLE
Feature/tutorial install

### DIFF
--- a/getting-started/getting-started-linux.html
+++ b/getting-started/getting-started-linux.html
@@ -27,10 +27,10 @@
             Linux users can install Egison with <code>apt</code> (or <code>dpkg</code>) or <code>yum</code> by the following simple commands!
           </p>
 
-          <pre><code>$ sudo yum install https://git.io/egison.x86_64.rpm</code></pre>
+          <pre><code>$ sudo yum install https://git.io/egison.x86_64.rpm https://git.io/egison-tutorial.x86_64.rpm</code></pre>
 
-         <pre><code>$ wget https://git.io/egison.x86_64.deb
-$ sudo dpkg -i ./egison.x86_64.deb</code></pre>
+         <pre><code>$ wget https://git.io/egison.x86_64.deb https://git.io/egison-tutorial.x86_64.deb
+$ sudo dpkg -i ./egison*.deb</code></pre>
 
           <h2 id="how-to-install">How to install Egison (Haskell Platform)</h2>
 

--- a/getting-started/getting-started-linux.html
+++ b/getting-started/getting-started-linux.html
@@ -24,7 +24,7 @@
           <h2 id="how-to-install-homebrew">How to install Egison (Packages)</h2>
 
           <p>
-            Linux users can install Egison with <code>apt</code> (or <code>dpkg</code>) or <code>yum</code> by the following simple commands!
+            Linux users can install Egison with <code>yum</code> or <code>dpkg</code> by the following simple commands!
           </p>
 
           <pre><code>$ sudo yum install https://git.io/egison.x86_64.rpm https://git.io/egison-tutorial.x86_64.rpm</code></pre>

--- a/getting-started/getting-started-mac.html
+++ b/getting-started/getting-started-mac.html
@@ -29,7 +29,7 @@
 
           <pre><code>$ brew update
 $ brew tap egison/egison
-$ brew install egison</code></pre>
+$ brew install egison egison-tutorial</code></pre>
 
           <h2 id="how-to-install-cabal">How to install Egison (Haskell Platform)</h2>
 

--- a/ja/getting-started/getting-started-linux.html
+++ b/ja/getting-started/getting-started-linux.html
@@ -27,10 +27,10 @@
             Linux ユーザーは、<code>apt</code> (または <code>dpkg</code>) または <code>yum</code> を使って簡単にEgisonをインストールできます。
           </p>
 
-          <pre><code>$ sudo yum install https://git.io/egison.x86_64.rpm</code></pre>
+          <pre><code>$ sudo yum install https://git.io/egison.x86_64.rpm https://git.io/egison-tutorial.x86_64.rpm</code></pre>
 
-         <pre><code>$ wget https://git.io/egison.x86_64.deb
-$ sudo dpkg -i ./egison.x86_64.deb</code></pre>
+         <pre><code>$ wget https://git.io/egison.x86_64.deb https://git.io/egison-tutorial.x86_64.deb
+$ sudo dpkg -i ./egison*.deb</code></pre>
 
           <h2 id="how-to-install">Egison のインストール方法 (Haskell Platform)</h2>
 

--- a/ja/getting-started/getting-started-linux.html
+++ b/ja/getting-started/getting-started-linux.html
@@ -24,7 +24,7 @@
           <h2 id="how-to-install-homebrew">Egison のインストール方法 (Packages)</h2>
 
           <p>
-            Linux ユーザーは、<code>apt</code> (または <code>dpkg</code>) または <code>yum</code> を使って簡単にEgisonをインストールできます。
+            Linux ユーザーは、<code>yum</code> または <code>dpkg</code> を使って簡単にEgisonをインストールできます。
           </p>
 
           <pre><code>$ sudo yum install https://git.io/egison.x86_64.rpm https://git.io/egison-tutorial.x86_64.rpm</code></pre>

--- a/ja/getting-started/getting-started-mac.html
+++ b/ja/getting-started/getting-started-mac.html
@@ -30,7 +30,7 @@
 
           <pre><code>$ brew update
 $ brew tap egison/egison
-$ brew install egison</code></pre>
+$ brew install egison egison-tutorial</code></pre>
 
           <h2 id="how-to-install-cabal">Egison のインストール方法(Haskell Platform)</h2>
 


### PR DESCRIPTION
Now, Mac/Linux installation procedures support `egison-tutorial`.

Mac: https://github.com/egison/homebrew-egison
Linux: https://github.com/egison/egison-package-builder