### PR TITLE
Deprecate array

### DIFF
--- a/libraries/core/base.html
+++ b/libraries/core/base.html
@@ -78,9 +78,6 @@
 <dt id="demo-compose3"><code>compose3</code></dt>
 <dd><textarea class="code">((compose3 fst snd fst) [[1 [2 3]] 4]);=>2</textarea></dd>
 
-<dt id="demo-ref"><code>ref</code></dt>
-<dd><textarea class="code">(ref [| 1 2 3 |] 2);=>2</textarea></dd>
-
 <dt id="demo-eq-m"><code>eq?/m</code></dt>
 <dd><textarea class="code">(eq?/m integer 1 1);=>#t</textarea></dd>
 

--- a/manual/primitive-functions.html
+++ b/manual/primitive-functions.html
@@ -239,9 +239,6 @@ We don't describe precise behaviour of them, but give simply examples.
 <dt id="demo-collection-p"><code>collection?</code></dt>
 <dd><textarea class="code">(collection? {});=>#t</textarea></dd>
 
-<dt id="demo-array-p"><code>array?</code></dt>
-<dd><textarea class="code">(array? (|1 2 3|));=>#t</textarea></dd>
-
 <dt id="demo-hash-p"><code>hash?</code></dt>
 <dd><textarea class="code">(hash? {|[1 1] [2 12]|});=>#t</textarea></dd>
 

--- a/templates/tables/base.html
+++ b/templates/tables/base.html
@@ -18,7 +18,7 @@
     <tr>
       <td>Basics</td>
       <td>
-        <a href="/libraries/core/base.html#demo-id"><code>id</code></a> <a href="/libraries/core/base.html#demo-fst"><code>fst</code></a> <a href="/libraries/core/base.html#demo-snd"><code>snd</code></a> <a href="/libraries/core/base.html#demo-compose"><code>compose</code></a> <a href="/libraries/core/base.html#demo-compose3"><code>compose3</code></a> <a href="/libraries/core/base.html#demo-ref"><code>ref</code></a> <a href="/libraries/core/base.html#demo-eq-m"><code>eq?/m</code></a>
+        <a href="/libraries/core/base.html#demo-id"><code>id</code></a> <a href="/libraries/core/base.html#demo-fst"><code>fst</code></a> <a href="/libraries/core/base.html#demo-snd"><code>snd</code></a> <a href="/libraries/core/base.html#demo-compose"><code>compose</code></a> <a href="/libraries/core/base.html#demo-compose3"><code>compose3</code></a> <a href="/libraries/core/base.html#demo-eq-m"><code>eq?/m</code></a>
       </td>
     </tr>
     <tr>

--- a/templates/tables/primitives.html
+++ b/templates/tables/primitives.html
@@ -29,7 +29,7 @@
     </tr>
     <tr>
       <td>Predicates</td>
-      <td><a href="/manual/primitive-functions.html#demo-bool-p"><code>bool?</code></a> <a href="/manual/primitive-functions.html#demo-integer-p"><code>integer?</code></a> <a href="/manual/primitive-functions.html#demo-rational-p"><code>rational?</code></a> <a href="/manual/primitive-functions.html#demo-char-p"><code>char?</code></a> <a href="/manual/primitive-functions.html#demo-string-p"><code>string?</code></a> <a href="/manual/primitive-functions.html#demo-"><code>tuple?</code></a> <a href="/manual/primitive-functions.html#demo-collection-p"><code>collection?</code></a> <a href="/manual/primitive-functions.html#demo-array-p"><code>array?</code></a> <a href="/manual/primitive-functions.html#demo-hash-p"><code>hash?</code></a></td></td>
+      <td><a href="/manual/primitive-functions.html#demo-bool-p"><code>bool?</code></a> <a href="/manual/primitive-functions.html#demo-integer-p"><code>integer?</code></a> <a href="/manual/primitive-functions.html#demo-rational-p"><code>rational?</code></a> <a href="/manual/primitive-functions.html#demo-char-p"><code>char?</code></a> <a href="/manual/primitive-functions.html#demo-string-p"><code>string?</code></a> <a href="/manual/primitive-functions.html#demo-"><code>tuple?</code></a> <a href="/manual/primitive-functions.html#demo-collection-p"><code>collection?</code></a> <a href="/manual/primitive-functions.html#demo-hash-p"><code>hash?</code></a></td></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This PR deletes manual for `ref` and `array?`.